### PR TITLE
Build GeoScript with JDK 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Upload geoscript-groovy.zip

--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,10 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <compilerId>groovy-eclipse-compiler</compilerId>
+                    <compilerArgs>
+                        <arg>--add-exports</arg>
+                        <arg>java.desktop/sun.awt.image=ALL-UNNAMED</arg>
+                    </compilerArgs>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -396,6 +400,7 @@
                 <configuration>
                     <forkMode>once</forkMode>
                     <argLine>@{argLine} -Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=1024m</argLine>
+                    <argLine>@{argLine} --add-exports java.desktop/sun.awt.image=ALL-UNNAMED</argLine>
                     <systemPropertyVariables>
                         <org.geotools.referencing.forceXY>true</org.geotools.referencing.forceXY>
                     </systemPropertyVariables>

--- a/src/main/groovy/geoscript/filter/Color.groovy
+++ b/src/main/groovy/geoscript/filter/Color.groovy
@@ -345,7 +345,7 @@ class Color extends Expression {
             int r = color[0].toInteger()
             int g = color[1].toInteger()
             int b =  color[2].toInteger()
-            int a = color.size > 3 ? color[3].toInteger() : 0
+            int a = color.size() > 3 ? color[3].toInteger() : 0
             return new java.awt.Color(r, g, b, a)
         }
         // RGB as Map [r:255,g:255,b:0,a:125]


### PR DESCRIPTION
JDK 17 has been out for several years. GeoScript should be made compatible with JDK 17 for increased availability across applications.

Detailed changes:

- Geoscript fails at runtime when used in Java 17 due to using the size parameter directly in the Color class. JDK 17 restricts usage of internal parameters to a greater degree. I've updated geoscript to build with JDK 17 and fixed the corresponding issue. 
- Furthermore, Geoscript relies on some sun packages that are no longer exposed by default in JDK 17, so I had to manually expose those in the compile step as well.